### PR TITLE
Store maximum flow value in 'flow_value' attribute of residual networks

### DIFF
--- a/networkx/algorithms/flow/ford_fulkerson.py
+++ b/networkx/algorithms/flow/ford_fulkerson.py
@@ -17,15 +17,15 @@ __all__ = ['ford_fulkerson',
 def ford_fulkerson_impl(G, s, t, capacity):
     """Find a maximum single-commodity flow using the Ford-Fulkerson
     algorithm.
-    
-    This function returns both the value of the maximum flow and the 
+
+    This function returns both the value of the maximum flow and the
     auxiliary network resulting after finding the maximum flow, which
-    is also named residual network in the literature. The 
-    auxiliary network has edges with capacity equal to the capacity 
-    of the edge in the original network minus the flow that went 
-    throught that edge. Notice that it can happen that a flow 
-    from v to u is allowed in the auxiliary network, though disallowed 
-    in the original network. A dictionary with infinite capacity edges 
+    is also named residual network in the literature. The
+    auxiliary network has edges with capacity equal to the capacity
+    of the edge in the original network minus the flow that went
+    throught that edge. Notice that it can happen that a flow
+    from v to u is allowed in the auxiliary network, though disallowed
+    in the original network. A dictionary with infinite capacity edges
     can be found as an attribute of the auxiliary network.
 
     Parameters
@@ -53,8 +53,8 @@ def ford_fulkerson_impl(G, s, t, capacity):
         Value of the maximum flow, i.e., net outflow from the source.
 
     auxiliary : DiGraph
-        Residual/auxiliary network after finding the maximum flow. 
-        A dictionary with infinite capacity edges can be found as 
+        Residual/auxiliary network after finding the maximum flow.
+        A dictionary with infinite capacity edges can be found as
         an attribute of this network: auxiliary.graph['inf_capacity_flows']
 
     Raises
@@ -65,7 +65,7 @@ def ford_fulkerson_impl(G, s, t, capacity):
         NetworkXError is raised.
 
     NetworkXUnbounded
-        If the graph has a path of infinite capacity, the value of a 
+        If the graph has a path of infinite capacity, the value of a
         feasible flow on the graph is unbounded above and the function
         raises a NetworkXUnbounded.
 
@@ -127,11 +127,11 @@ def ford_fulkerson_impl(G, s, t, capacity):
             path_capacity = min([auxiliary[u][v][capacity]
                                 for u, v in path_edges
                                 if capacity in auxiliary[u][v]])
-        except ValueError: 
+        except ValueError:
             # path of infinite capacity implies no max flow
             raise nx.NetworkXUnbounded(
                     "Infinite capacity path, flow unbounded above.")
-        
+
         flow_value += path_capacity
 
         # Augment the flow along the path.
@@ -149,7 +149,7 @@ def ford_fulkerson_impl(G, s, t, capacity):
                     auxiliary[v][u][capacity] += path_capacity
             else:
                 auxiliary.add_edge(v, u, {capacity: path_capacity})
-    
+
     auxiliary.graph['inf_capacity_flows'] = inf_capacity_flows
     return flow_value, auxiliary
 
@@ -229,9 +229,9 @@ def _create_flow_dict(G, H, capacity='capacity'):
 def ford_fulkerson(G, s, t, capacity='capacity', legacy=True):
     """Find a maximum single-commodity flow using the Ford-Fulkerson
     algorithm.
-    
+
     This is the legacy implementation of maximum flow. See Notes below.
-    
+
     This algorithm uses Edmonds-Karp-Dinitz path selection rule which
     guarantees a running time of `O(nm^2)` for `n` nodes and `m` edges.
 
@@ -257,7 +257,7 @@ def ford_fulkerson(G, s, t, capacity='capacity', legacy=True):
 
     legacy : bool
         If True this function behaves as before 1.9, returning a tuple
-        with (flow_value, flow_dict). Otherwise, it will return the 
+        with (flow_value, flow_dict). Otherwise, it will return the
         residual network to be compatible with the new interface to
         flow algorithms introduced in 1.9. Default value: True.
 
@@ -271,7 +271,7 @@ def ford_fulkerson(G, s, t, capacity='capacity', legacy=True):
         flow_dict[u][v] is the flow edge (u, v).
 
     R : NetworkX DiGraph
-        If legacy is False, this function returns the residual network 
+        If legacy is False, this function returns the residual network
         after finding the maximum flow.
 
     Raises
@@ -282,7 +282,7 @@ def ford_fulkerson(G, s, t, capacity='capacity', legacy=True):
         NetworkXError is raised.
 
     NetworkXUnbounded
-        If the graph has a path of infinite capacity, the value of a 
+        If the graph has a path of infinite capacity, the value of a
         feasible flow on the graph is unbounded above and the function
         raises a NetworkXUnbounded.
 
@@ -296,19 +296,19 @@ def ford_fulkerson(G, s, t, capacity='capacity', legacy=True):
 
     Notes
     -----
-    This is a legacy implementation of maximum flow (before 1.9). By 
+    This is a legacy implementation of maximum flow (before 1.9). By
     default this function returns a tuple with the flow value and the
     flow dictionary, thus it is backwards compatible. If the parameter
     legacy is False, then this function returns the residual network
     resulting after computing the maximum flow, which is what the
     new maximum flow functions return.
 
-    Note however that the residual network returned by this function 
+    Note however that the residual network returned by this function
     does not follow the conventions for residual networks used by the
-    new algorithms introduced in 1.9. This residual network has edges 
-    with capacity equal to the capacity of the edge in the original 
-    network minus the flow that went throught that edge. A dictionary 
-    with infinite capacity edges can be found as an attribute of the 
+    new algorithms introduced in 1.9. This residual network has edges
+    with capacity equal to the capacity of the edge in the original
+    network minus the flow that went throught that edge. A dictionary
+    with infinite capacity edges can be found as an attribute of the
     residual network.
 
     Examples
@@ -331,7 +331,7 @@ def ford_fulkerson(G, s, t, capacity='capacity', legacy=True):
     >>> flow_value
     3.0
 
-    You can set the legacy parameter to False to get the residual 
+    You can set the legacy parameter to False to get the residual
     network after computing the maximum flow. This network has graph
     attributes that contain: a dictionary with edges with infinite
     capacity flows, the flow value, and a dictionary of flows:
@@ -392,7 +392,7 @@ def ford_fulkerson_flow(G, s, t, capacity='capacity'):
         NetworkXError is raised.
 
     NetworkXUnbounded
-        If the graph has a path of infinite capacity, the value of a 
+        If the graph has a path of infinite capacity, the value of a
         feasible flow on the graph is unbounded above and the function
         raises a NetworkXUnbounded.
 
@@ -412,7 +412,7 @@ def ford_fulkerson_flow(G, s, t, capacity='capacity'):
     >>> F = flow.ford_fulkerson_flow(G, 'x', 'y')
     >>> for u, v in sorted(G.edges_iter()):
     ...     print('(%s, %s) %.2f' % (u, v, F[u][v]))
-    ... 
+    ...
     (a, c) 2.00
     (b, c) 0.00
     (b, d) 1.00

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -14,10 +14,10 @@ __all__ = ['maximum_flow',
            'min_cut']
 
 
-def maximum_flow(G, s, t, capacity='capacity', flow_func=None, 
+def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
                  value_only=True, **kwargs):
     """Find a maximum single-commodity flow.
-    
+
     Parameters
     ----------
     G : NetworkX graph
@@ -38,16 +38,16 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
         infinite capacity. Default value: 'capacity'.
 
     flow_func : function
-        A function for computing the maximum flow among a pair of nodes 
-        in a capacitated graph. The function has to accept at least three 
-        parameters: a Graph or Digraph, a source node, and a target node. 
+        A function for computing the maximum flow among a pair of nodes
+        in a capacitated graph. The function has to accept at least three
+        parameters: a Graph or Digraph, a source node, and a target node.
         And return a residual network that follows NetworkX conventions
-        (see Notes). If flow_func is None the default maximum 
-        flow function (:meth:`preflow_push`) is used. See below for 
+        (see Notes). If flow_func is None the default maximum
+        flow function (:meth:`preflow_push`) is used. See below for
         alternative algorithms. Default value: None.
 
     value_only : boolean
-        If True compute only the value of the maximum flow. If False 
+        If True compute only the value of the maximum flow. If False
         compute the actual flows. Default value: True.
 
     kwargs : Any other keyword parameter is passed to the function that
@@ -71,10 +71,10 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
         NetworkXError is raised.
 
     NetworkXUnbounded
-        If the graph has a path of infinite capacity, the value of a 
+        If the graph has a path of infinite capacity, the value of a
         feasible flow on the graph is unbounded above and the function
         raises a NetworkXUnbounded.
-    
+
     See also
     --------
     :meth:`minimum_cut`
@@ -89,22 +89,24 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
     network that follows NetworkX conventions:
 
     The residual network :samp:`R` from an input graph :samp:`G` has the
-    same nodes than :samp:`G`. :samp:`R` is a DiGraph that contains a pair
+    same nodes as :samp:`G`. :samp:`R` is a DiGraph that contains a pair
     of edges :samp:`(u, v)` and :samp:`(v, u)` iff :samp:`(u, v)` is not a
     self-loop, and at least one of :samp:`(u, v)` and :samp:`(v, u)` exists
-    in :samp:`G`. For each node :samp:`u` in :samp:`R`,
-    :samp:`R.node[u]['excess']` represents the difference between flow into
-    :samp:`u` and flow out of :samp:`u`. Thus the maximum flow value is
-    stored in :samp:`R.node[t]['excess']`, where :samp:`t` is the sink node.
+    in :samp:`G`.
 
-    For each edge :samp:`(u, v)` in :samp:`R`, :samp:`R[u][v]['capacity']` 
-    is equal to the capacity of :samp:`(u, v)` in :samp:`G` if it exists 
-    in :samp:`G` or zero otherwise. If the capacity is infinite, 
-    :samp:`R[u][v]['capacity']` will have a high arbitrary finite value 
-    that does not affect the solution of the problem. For each edge 
-    :samp:`(u, v)` in :samp:`R`, :samp:`R[u][v]['flow']` represents 
-    the flow function of :samp:`(u, v)` and satisfies 
-    :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
+    For each edge :samp:`(u, v)` in :samp:`R`, :samp:`R[u][v]['capacity']`
+    is equal to the capacity of :samp:`(u, v)` in :samp:`G` if it exists
+    in :samp:`G` or zero otherwise. If the capacity is infinite,
+    :samp:`R[u][v]['capacity']` will have a high arbitrary finite value
+    that does not affect the solution of the problem. This value is stored in
+    :samp:`R.graph['inf']`. For each edge :samp:`(u, v)` in :samp:`R`,
+    :samp:`R[u][v]['flow']` represents the flow function of :samp:`(u, v)` and
+    satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
+
+    The flow value, defined as the total flow into :samp:`t`, the sink, is
+    stored in :samp:`R.node[t]['flow_value']`.
+
+    Specific algorithms may store extra data in :samp:`R`.
 
     The legacy :meth:`ford_fulkerson` maximum flow implementation doesn't
     follow this conventions but it is supported as a valid flow_func.
@@ -136,11 +138,11 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
     >>> print(flow_dict['x']['b'])
     1.0
 
-    You can also use alternative algorithms for computing the 
+    You can also use alternative algorithms for computing the
     maximum flow by using the flow_func parameter.
 
-    >>> assert(flow_value == 
-    ...         nx.maximum_flow(G, 'x', 'y', 
+    >>> assert(flow_value ==
+    ...         nx.maximum_flow(G, 'x', 'y',
     ...                         flow_func=nx.shortest_augmenting_path))
 
     """
@@ -160,7 +162,7 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
     R = flow_func(G, s, t, capacity=capacity, value_only=value_only, **kwargs)
 
     if value_only:
-        return R.node[t]['excess']
+        return R.graph['flow_value']
 
     # Build the flow dictionary
     flow_dict = {}
@@ -171,7 +173,7 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
     return flow_dict
 
 
-def minimum_cut(G, s, t, capacity='capacity', flow_func=None, 
+def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
                 value_only=True, **kwargs):
     """Compute the value of a minimum (s, t)-cut.
 
@@ -198,12 +200,12 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
         infinite capacity. Default value: 'capacity'.
 
     flow_func : function
-        A function for computing the maximum flow among a pair of nodes 
-        in a capacitated graph. The function has to accept at least three 
-        parameters: a Graph or Digraph, a source node, and a target node. 
+        A function for computing the maximum flow among a pair of nodes
+        in a capacitated graph. The function has to accept at least three
+        parameters: a Graph or Digraph, a source node, and a target node.
         And return a residual network that follows NetworkX conventions
-        (see Notes). If flow_func is None the default maximum 
-        flow function (:meth:`preflow_push`) is used. See below for 
+        (see Notes). If flow_func is None the default maximum
+        flow function (:meth:`preflow_push`) is used. See below for
         alternative algorithms. Default value: None.
 
     value_only : boolean
@@ -221,7 +223,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
     partition : pair of node sets
         A partitioning of the nodes that defines a minimum cut if
         value_only is False.
-    
+
     Raises
     ------
     NetworkXUnbounded
@@ -230,7 +232,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
 
     See also
     --------
-    maximum_flow    
+    maximum_flow
     :meth:`edmonds_karp`
     :meth:`ford_fulkerson`
     :meth:`preflow_push`
@@ -242,25 +244,24 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
     network that follows NetworkX conventions:
 
     The residual network :samp:`R` from an input graph :samp:`G` has the
-    same nodes than :samp:`G`. :samp:`R` is a DiGraph that contains a pair
+    same nodes as :samp:`G`. :samp:`R` is a DiGraph that contains a pair
     of edges :samp:`(u, v)` and :samp:`(v, u)` iff :samp:`(u, v)` is not a
     self-loop, and at least one of :samp:`(u, v)` and :samp:`(v, u)` exists
-    in :samp:`G`. For each node :samp:`u` in :samp:`R`,
-    :samp:`R.node[u]['excess']` represents the difference between flow into
-    :samp:`u` and flow out of :samp:`u`. Thus the maximum flow value is
-    stored in :samp:`R.node[t]['excess']`, where :samp:`t` is the sink node.
+    in :samp:`G`.
 
-    For each edge :samp:`(u, v)` in :samp:`R`, :samp:`R[u][v]['capacity']` 
-    is equal to the capacity of :samp:`(u, v)` in :samp:`G` if it exists 
-    in :samp:`G` or zero otherwise. If the capacity is infinite, 
-    :samp:`R[u][v]['capacity']` will have a high arbitrary finite value 
-    that does not affect the solution of the problem. For each edge 
-    :samp:`(u, v)` in :samp:`R`, :samp:`R[u][v]['flow']` represents 
-    the flow function of :samp:`(u, v)` and satisfies 
-    :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
+    For each edge :samp:`(u, v)` in :samp:`R`, :samp:`R[u][v]['capacity']`
+    is equal to the capacity of :samp:`(u, v)` in :samp:`G` if it exists
+    in :samp:`G` or zero otherwise. If the capacity is infinite,
+    :samp:`R[u][v]['capacity']` will have a high arbitrary finite value
+    that does not affect the solution of the problem. This value is stored in
+    :samp:`R.graph['inf']`. For each edge :samp:`(u, v)` in :samp:`R`,
+    :samp:`R[u][v]['flow']` represents the flow function of :samp:`(u, v)` and
+    satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
 
-    The legacy :meth:`ford_fulkerson` maximum flow implementation doesn't
-    follow this conventions but it is supported as a valid flow_func.
+    Specific algorithms may store extra data in :samp:`R`.
+
+    The flow value, defined as the total flow into :samp:`t`, the sink, is
+    stored in :samp:`R.node[t]['flow_value']`.
 
     Examples
     --------
@@ -291,7 +292,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
     'partition' here is a tuple with the two sets of nodes that define
     the minimum cut. You can compute the cut set of edges that induce
     the minimum cut as follows:
-    
+
     >>> cutset = set()
     >>> for u, nbrs in ((n, G[n]) for n in reachable):
     ...     cutset.update((u, v) for v in nbrs if v in non_reachable)
@@ -299,10 +300,10 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
     [('c', 'y'), ('x', 'b')]
     >>> assert(min_cut_value == sum(G.edge[u][v]['capacity'] for (u, v) in cutset))
 
-    You can also use alternative algorithms for computing the 
+    You can also use alternative algorithms for computing the
     minimum cut by using the flow_func parameter.
 
-    >>> assert(min_cut_value == 
+    >>> assert(min_cut_value ==
     ...         nx.minimum_cut(G, 'x', 'y', flow_func=nx.shortest_augmenting_path))
 
     """
@@ -318,16 +319,16 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
         if value_only:
             return R.graph['flow_value']
     else:
-        R = flow_func(G, s, t, capacity=capacity, value_only=value_only, 
+        R = flow_func(G, s, t, capacity=capacity, value_only=value_only,
                       **kwargs)
         if value_only:
-            return R.node[t]['excess']
+            return R.graph['flow_value']
         # Remove saturated edges from the residual network for computing
         # the minimum cut.
         R.remove_edges_from((u, v) for u, v, d in R.edges(data=True)
-                            if d['capacity'] - d['flow'] == 0)
+                            if d['flow'] == d['capacity'])
 
-    # Reachable and non reachable nodes from source in the 
+    # Reachable and non reachable nodes from source in the
     # residual network form the node partition that defines
     # the minimum cut.
     reachable = set(nx.single_source_shortest_path(R, s))

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -6,11 +6,11 @@ from functools import partial
 from nose.tools import *
 
 import networkx as nx
-from networkx.algorithms.flow.utils import * 
-from networkx.algorithms.flow.edmonds_karp import * 
-from networkx.algorithms.flow.ford_fulkerson import * 
-from networkx.algorithms.flow.preflow_push import * 
-from networkx.algorithms.flow.shortest_augmenting_path import * 
+from networkx.algorithms.flow.utils import *
+from networkx.algorithms.flow.edmonds_karp import *
+from networkx.algorithms.flow.ford_fulkerson import *
+from networkx.algorithms.flow.preflow_push import *
+from networkx.algorithms.flow.shortest_augmenting_path import *
 
 ford_fulkerson = partial(ford_fulkerson, legacy=False)
 ford_fulkerson.__name__ = 'ford_fulkerson'
@@ -36,7 +36,7 @@ def compute_cutset(G, partition):
 def validate_flows(G, s, t, flowDict, solnValue, capacity, flow_func):
     assert_equal(set(G), set(flowDict), msg=msg.format(flow_func.__name__))
     for u in G:
-        assert_equal(set(G[u]), set(flowDict[u]), 
+        assert_equal(set(G[u]), set(flowDict[u]),
                      msg=msg.format(flow_func.__name__))
     excess = dict((u, 0) for u in flowDict)
     for u in flowDict:
@@ -56,12 +56,12 @@ def validate_flows(G, s, t, flowDict, solnValue, capacity, flow_func):
 
 
 def validate_cuts(G, s, t, solnValue, partition, capacity, flow_func):
-    assert_true(all(n in G for n in partition[0]), 
+    assert_true(all(n in G for n in partition[0]),
                 msg=msg.format(flow_func.__name__))
-    assert_true(all(n in G for n in partition[1]), 
+    assert_true(all(n in G for n in partition[1]),
                 msg=msg.format(flow_func.__name__))
     cutset = compute_cutset(G, partition)
-    assert_true(all(G.has_edge(u, v) for (u, v) in cutset), 
+    assert_true(all(G.has_edge(u, v) for (u, v) in cutset),
                 msg=msg.format(flow_func.__name__))
     assert_equal(solnValue, sum(G[u][v][capacity] for (u, v) in cutset),
                 msg=msg.format(flow_func.__name__))
@@ -70,7 +70,7 @@ def validate_cuts(G, s, t, solnValue, partition, capacity, flow_func):
     if not G.is_directed():
         assert_false(nx.is_connected(H), msg=msg.format(flow_func.__name__))
     else:
-        assert_false(nx.is_strongly_connected(H), 
+        assert_false(nx.is_strongly_connected(H),
                      msg=msg.format(flow_func.__name__))
 
 
@@ -79,10 +79,11 @@ def compare_flows_and_cuts(G, s, t, solnFlows, solnValue, capacity='capacity'):
         R = flow_func(G, s, t, capacity)
         # Test both legacy and new implementations.
         legacy = R.graph.get('algorithm') == "ford_fulkerson_legacy"
+        flow_value = R.graph['flow_value']
         if legacy:
-            flow_value, flow_dict = R.graph['flow_value'], R.graph['flow_dict']
+            flow_dict = R.graph['flow_dict']
         else:
-            flow_value, flow_dict = R.node[t]['excess'], build_flow_dict(G, R)
+            flow_dict = build_flow_dict(G, R)
         assert_equal(flow_value, solnValue, msg=msg.format(flow_func.__name__))
         if legacy:
             assert_equal(flow_dict, solnFlows, msg=msg.format(flow_func.__name__))
@@ -357,9 +358,9 @@ class TestMaxFlowMinCutInterface:
         G = nx.Graph()
         G.add_weighted_edges_from([(0,1,1),(1,2,1),(2,3,1)],weight='capacity')
         for element in elements:
-            assert_raises(nx.NetworkXError, 
+            assert_raises(nx.NetworkXError,
                             nx.maximum_flow, G, 0, 1, flow_func=element)
-            assert_raises(nx.NetworkXError, 
+            assert_raises(nx.NetworkXError,
                             nx.minimum_cut, G, 0, 1, flow_func=element)
 
     def test_flow_func_parameter(self):
@@ -386,13 +387,13 @@ class TestMaxFlowMinCutInterface:
         G.add_edge(0, 1, capacity = 1.0)
         G.add_edge(1, 2, capacity = 1.0)
         fv = 1.0
-        assert_equal(fv, nx.maximum_flow(G, 0, 2, 
+        assert_equal(fv, nx.maximum_flow(G, 0, 2,
                             flow_func=nx.shortest_augmenting_path, two_phase=True))
-        assert_equal(fv, nx.minimum_cut(G, 0, 2, 
+        assert_equal(fv, nx.minimum_cut(G, 0, 2,
                             flow_func=nx.shortest_augmenting_path, two_phase=True))
         assert_equal(fv, nx.maximum_flow(G, 0, 2,
                             flow_func=nx.preflow_push, global_relabel_freq=5))
-        assert_equal(fv, nx.minimum_cut(G, 0, 2, 
+        assert_equal(fv, nx.minimum_cut(G, 0, 2,
                             flow_func=nx.preflow_push, global_relabel_freq=5))
 
 
@@ -401,7 +402,7 @@ def test_preflow_push_global_relabel_freq():
     G = nx.DiGraph()
     G.add_edge(1, 2, capacity=1)
     R = nx.preflow_push(G, 1, 2, global_relabel_freq=None)
-    assert_equal(R.node[2]['excess'], 1)
+    assert_equal(R.graph['flow_value'], 1)
     assert_raises(nx.NetworkXError, preflow_push, G, 1, 2,
                   global_relabel_freq=-1)
 
@@ -414,6 +415,6 @@ def test_shortest_augmenting_path_two_phase():
         G.add_path(((i, j) for j in range(p)), capacity=1)
         G.add_edge((i, p - 1), 't', capacity=1)
     R = shortest_augmenting_path(G, 's', 't', two_phase=True)
-    assert_equal(R.node['t']['excess'], k)
+    assert_equal(R.graph['flow_value'], k)
     R = shortest_augmenting_path(G, 's', 't', two_phase=False)
-    assert_equal(R.node['t']['excess'], k)
+    assert_equal(R.graph['flow_value'], k)

--- a/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
+++ b/networkx/algorithms/flow/tests/test_maxflow_large_graph.py
@@ -19,7 +19,7 @@ from networkx.algorithms.flow.ford_fulkerson import *
 from networkx.algorithms.flow.preflow_push import *
 from networkx.algorithms.flow.shortest_augmenting_path import *
 
-flow_funcs = [edmonds_karp, ford_fulkerson, preflow_push, 
+flow_funcs = [edmonds_karp, ford_fulkerson, preflow_push,
               shortest_augmenting_path]
 
 ford_fulkerson = partial(ford_fulkerson, legacy=False)
@@ -27,7 +27,7 @@ ford_fulkerson.__name__ = 'ford_fulkerson'
 preflow_push = partial(preflow_push, value_only=False)
 preflow_push.__name__ = 'preflow_push'
 
-flow_funcs = [edmonds_karp, ford_fulkerson, preflow_push, 
+flow_funcs = [edmonds_karp, ford_fulkerson, preflow_push,
                 shortest_augmenting_path]
 
 msg = "Assertion failed in function: {0}"
@@ -62,14 +62,15 @@ def read_graph(name):
 
 def validate_flows(G, s, t, solnValue, R, flow_func):
     legacy = R.graph.get('algorithm') == "ford_fulkerson_legacy"
+    flowValue = R.graph['flow_value']
     if legacy:
-        flowValue, flowDict = R.graph['flow_value'], R.graph['flow_dict']
+        flowDict = R.graph['flow_dict']
     else:
-        flowValue, flowDict = R.node[t]['excess'], build_flow_dict(G, R)
+        flowDict = build_flow_dict(G, R)
     assert_equal(solnValue, flowValue, msg=msg.format(flow_func.__name__))
     assert_equal(set(G), set(flowDict), msg=msg.format(flow_func.__name__))
     for u in G:
-        assert_equal(set(G[u]), set(flowDict[u]), 
+        assert_equal(set(G[u]), set(flowDict[u]),
                      msg=msg.format(flow_func.__name__))
     excess = dict((u, 0) for u in flowDict)
     for u in flowDict:
@@ -105,11 +106,7 @@ class TestMaxflowLargeGraph:
 
         for flow_func in flow_funcs:
             R = flow_func(G, 1, 2)
-            legacy = R.graph.get('algorithm') == "ford_fulkerson_legacy"
-            if legacy:
-                flow_value = R.graph['flow_value']
-            else:
-                flow_value = R.node[2]['excess']
+            flow_value = R.graph['flow_value']
             assert_equal(flow_value, 5 * (N - 1),
                          msg=msg.format(flow_func.__name__))
 
@@ -119,11 +116,7 @@ class TestMaxflowLargeGraph:
         G = gen_pyramid(N)
         for flow_func in flow_funcs:
             R = flow_func(G, (0, 0), 't')
-            legacy = R.graph.get('algorithm') == "ford_fulkerson_legacy"
-            if legacy:
-                flow_value = R.graph['flow_value']
-            else:
-                flow_value = R.node['t']['excess']
+            flow_value = R.graph['flow_value']
             assert_almost_equal(flow_value, 1.,
                                 msg=msg.format(flow_func.__name__))
 
@@ -148,10 +141,10 @@ class TestMaxflowLargeGraph:
         s = 1
         t = len(G)
         for flow_func in flow_funcs:
-            validate_flows(G, s, t, 11875108, flow_func(G, s, t), 
-                            flow_func)
+            validate_flows(G, s, t, 11875108, flow_func(G, s, t),
+                           flow_func)
 
     def test_preflow_push_global_relabel(self):
         G = read_graph('gw1')
         R = nx.preflow_push(G, 1, len(G), global_relabel_freq=50)
-        assert_equal(R.node[len(G)]['excess'], 1202018)
+        assert_equal(R.graph['flow_value'], 1202018)


### PR DESCRIPTION
This looks like a more natural way to expose the flow value than `R.node[t]['excess']`. Excess is undefined in augmenting path algorithms after all.
