### PR TITLE
Implement cutoff and fix value_only use in minimum_cut

### DIFF
--- a/networkx/algorithms/flow/edmonds_karp.py
+++ b/networkx/algorithms/flow/edmonds_karp.py
@@ -144,8 +144,9 @@ def edmonds_karp(G, s, t, capacity='capacity', value_only=False, cutoff=None):
         will be ignored by this algorithm because it is not applicable.
 
     cutoff : integer, float
-        If specified, the algorithm will stop when the flow value reaches or
-        exceeds the cutoff. Default value: None.
+        If specified, the algorithm will terminate when the flow value reaches
+        or exceeds the cutoff. In this case, it may be unable to immediately
+        determine a minimum cut. Default value: None.
 
     Returns
     -------

--- a/networkx/algorithms/flow/edmonds_karp.py
+++ b/networkx/algorithms/flow/edmonds_karp.py
@@ -14,7 +14,7 @@ from networkx.algorithms.flow.utils import *
 __all__ = ['edmonds_karp']
 
 
-def edmonds_karp_core(R, s, t):
+def edmonds_karp_core(R, s, t, cutoff):
     """Implementation of the Edmonds-Karp algorithm.
     """
     R_node = R.node
@@ -97,17 +97,19 @@ def edmonds_karp_core(R, s, t):
     return flow_value
 
 
-def edmonds_karp_impl(G, s, t, capacity):
+def edmonds_karp_impl(G, s, t, capacity, cutoff):
     """Implementation of the Edmonds-Karp algorithm.
     """
     R = build_residual_network(G, s, t, capacity)
 
-    R.graph['flow_value'] = edmonds_karp_core(R, s, t)
+    if cutoff is None:
+        cutoff = float('inf')
+    R.graph['flow_value'] = edmonds_karp_core(R, s, t, cutoff)
 
     return R
 
 
-def edmonds_karp(G, s, t, capacity='capacity', value_only=False):
+def edmonds_karp(G, s, t, capacity='capacity', value_only=False, cutoff=None):
     """Find a maximum single-commodity flow using the Edmonds-Karp algorithm.
 
     This function returns the residual network resulting after computing
@@ -140,6 +142,10 @@ def edmonds_karp(G, s, t, capacity='capacity', value_only=False):
     value_only : bool
         If True compute only the value of the maximum flow. This parameter
         will be ignored by this algorithm because it is not applicable.
+
+    cutoff : integer, float
+        If specified, the algorithm will stop when the flow value reaches or
+        exceeds the cutoff. Default value: None.
 
     Returns
     -------
@@ -205,6 +211,6 @@ def edmonds_karp(G, s, t, capacity='capacity', value_only=False):
     >>> assert(flow_value == R.graph['flow_value'])
 
     """
-    R = edmonds_karp_impl(G, s, t, capacity)
+    R = edmonds_karp_impl(G, s, t, capacity, cutoff)
     R.graph['algorithm'] = 'edmonds_karp'
     return R

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -104,7 +104,7 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
     satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
 
     The flow value, defined as the total flow into :samp:`t`, the sink, is
-    stored in :samp:`R.node[t]['flow_value']`.
+    stored in :samp:`R.graph['flow_value']`.
 
     Specific algorithms may store extra data in :samp:`R`.
 
@@ -261,7 +261,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
     Specific algorithms may store extra data in :samp:`R`.
 
     The flow value, defined as the total flow into :samp:`t`, the sink, is
-    stored in :samp:`R.node[t]['flow_value']`.
+    stored in :samp:`R.graph['flow_value']`.
 
     Examples
     --------

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -6,6 +6,7 @@ import networkx as nx
 
 # Define the default flow function for computing maximum flow.
 from .preflow_push import preflow_push
+from .utils import build_flow_dict
 default_flow_func = preflow_push
 
 __all__ = ['maximum_flow',
@@ -165,11 +166,7 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
         return R.graph['flow_value']
 
     # Build the flow dictionary
-    flow_dict = {}
-    for u in G:
-        flow_dict[u] = dict((v, 0) for v in G[u])
-        flow_dict[u].update((v, R[u][v]['flow']) for v in R[u]
-                            if R[u][v]['flow'] > 0)
+    flow_dict = build_flow_dict(G, R)
     return flow_dict
 
 
@@ -319,8 +316,7 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
         if value_only:
             return R.graph['flow_value']
     else:
-        R = flow_func(G, s, t, capacity=capacity, value_only=value_only,
-                      **kwargs)
+        R = flow_func(G, s, t, capacity=capacity, value_only=True, **kwargs)
         if value_only:
             return R.graph['flow_value']
         # Remove saturated edges from the residual network for computing
@@ -331,8 +327,8 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
     # Reachable and non reachable nodes from source in the
     # residual network form the node partition that defines
     # the minimum cut.
-    reachable = set(nx.single_source_shortest_path(R, s))
-    non_reachable = set(G) - reachable
+    non_reachable = set(nx.shortest_path_length(R, target=t))
+    reachable = set(G) - non_reachable
     return (reachable, non_reachable)
 
 

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -5,7 +5,10 @@ Maximum flow (and minimum cut) algorithms on capacitated graphs.
 import networkx as nx
 
 # Define the default flow function for computing maximum flow.
+from .edmonds_karp import edmonds_karp
+from .ford_fulkerson import ford_fulkerson
 from .preflow_push import preflow_push
+from .shortest_augmenting_path import shortest_augmenting_path
 from .utils import build_flow_dict
 default_flow_func = preflow_push
 
@@ -160,10 +163,10 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
         flow_func = default_flow_func
 
     if not callable(flow_func):
-        raise nx.NetworkXError("flow_func has to be callable")
+        raise nx.NetworkXError("flow_func has to be callable.")
 
     # Handle legacy ford_fulkerson
-    if flow_func is nx.ford_fulkerson:
+    if flow_func is ford_fulkerson:
         flow_value, flow_dict = flow_func(G, s, t, capacity=capacity)
         if value_only:
             return flow_value
@@ -325,11 +328,16 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
         flow_func = default_flow_func
 
     if not callable(flow_func):
-        raise nx.NetworkXError("flow_func has to be callable")
+        raise nx.NetworkXError("flow_func has to be callable.")
+
+    if (kwargs.get('cutoff') is not None and
+        flow_func in (edmonds_karp, ford_fulkerson, preflow_push,
+                      shortest_augmenting_path)):
+        raise nx.NetworkXError("cutoff should not be specified.")
 
     # Handle legacy ford_fulkerson.
-    if flow_func is nx.ford_fulkerson:
-        R = flow_func(G, s, t, capacity=capacity, legacy=False)
+    if flow_func is ford_fulkerson:
+        R = flow_func(G, s, t, capacity=capacity, legacy=False, **kwargs)
         if value_only:
             return R.graph['flow_value']
     else:

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -43,9 +43,11 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
         in a capacitated graph. The function has to accept at least three
         parameters: a Graph or Digraph, a source node, and a target node.
         And return a residual network that follows NetworkX conventions
-        (see Notes). If flow_func is None the default maximum
+        (see Notes). If flow_func is None, the default maximum
         flow function (:meth:`preflow_push`) is used. See below for
-        alternative algorithms. Default value: None.
+        alternative algorithms. The choice of the default function may change
+        from version to version and should not be relied on. Default value:
+        None.
 
     value_only : boolean
         If True compute only the value of the maximum flow. If False
@@ -105,9 +107,16 @@ def maximum_flow(G, s, t, capacity='capacity', flow_func=None,
     satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
 
     The flow value, defined as the total flow into :samp:`t`, the sink, is
-    stored in :samp:`R.graph['flow_value']`.
+    stored in :samp:`R.graph['flow_value']`. Reachability to :samp:`t` using
+    only edges :samp:`(u, v)` such that
+    :samp:`R[u][v]['flow'] < R[u][v]['capacity']` induces a minimum
+    :samp:`s`-:samp:`t` cut.
 
     Specific algorithms may store extra data in :samp:`R`.
+
+    The function should supports an optional boolean parameter value_only. When
+    True, it can optionally terminate the algorithm as soon as the maximum flow
+    value and the minimum cut can be determined.
 
     The legacy :meth:`ford_fulkerson` maximum flow implementation doesn't
     follow this conventions but it is supported as a valid flow_func.
@@ -196,14 +205,15 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
         attribute is not present, the edge is considered to have
         infinite capacity. Default value: 'capacity'.
 
-    flow_func : function
         A function for computing the maximum flow among a pair of nodes
         in a capacitated graph. The function has to accept at least three
         parameters: a Graph or Digraph, a source node, and a target node.
         And return a residual network that follows NetworkX conventions
-        (see Notes). If flow_func is None the default maximum
+        (see Notes). If flow_func is None, the default maximum
         flow function (:meth:`preflow_push`) is used. See below for
-        alternative algorithms. Default value: None.
+        alternative algorithms. The choice of the default function may change
+        from version to version and should not be relied on. Default value:
+        None.
 
     value_only : boolean
         If True compute only the value of the minimum cut. If False compute
@@ -255,10 +265,17 @@ def minimum_cut(G, s, t, capacity='capacity', flow_func=None,
     :samp:`R[u][v]['flow']` represents the flow function of :samp:`(u, v)` and
     satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
 
+    The flow value, defined as the total flow into :samp:`t`, the sink, is
+    stored in :samp:`R.graph['flow_value']`. Reachability to :samp:`t` using
+    only edges :samp:`(u, v)` such that
+    :samp:`R[u][v]['flow'] < R[u][v]['capacity']` induces a minimum
+    :samp:`s`-:samp:`t` cut.
+
     Specific algorithms may store extra data in :samp:`R`.
 
-    The flow value, defined as the total flow into :samp:`t`, the sink, is
-    stored in :samp:`R.graph['flow_value']`.
+    The function should supports an optional boolean parameter value_only. When
+    True, it can optionally terminate the algorithm as soon as the maximum flow
+    value and the minimum cut can be determined.
 
     Examples
     --------

--- a/networkx/algorithms/flow/shortest_augmenting_path.py
+++ b/networkx/algorithms/flow/shortest_augmenting_path.py
@@ -194,8 +194,9 @@ def shortest_augmenting_path(G, s, t, capacity='capacity', value_only=False,
         `O(\min(n^{2/3}, m^{1/2}) m)`. Default value: False.
 
     cutoff : integer, float
-        If specified, the algorithm will stop when the flow value reaches or
-        exceeds the cutoff. Default value: None.
+        If specified, the algorithm will terminate when the flow value reaches
+        or exceeds the cutoff. In this case, it may be unable to immediately
+        determine a minimum cut. Default value: None.
 
     Returns
     -------

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -418,3 +418,19 @@ def test_shortest_augmenting_path_two_phase():
     assert_equal(R.graph['flow_value'], k)
     R = shortest_augmenting_path(G, 's', 't', two_phase=False)
     assert_equal(R.graph['flow_value'], k)
+
+
+def test_cutoff():
+    k = 5
+    p = 1000
+    G = nx.DiGraph()
+    for i in range(k):
+        G.add_edge('s', (i, 0), capacity=2)
+        G.add_path(((i, j) for j in range(p)), capacity=2)
+        G.add_edge((i, p - 1), 't', capacity=2)
+    R = shortest_augmenting_path(G, 's', 't', two_phase=True, cutoff=k)
+    ok_(k <= R.graph['flow_value'] <= 2 * k)
+    R = shortest_augmenting_path(G, 's', 't', two_phase=False, cutoff=k)
+    ok_(k <= R.graph['flow_value'] <= 2 * k)
+    R = edmonds_karp(G, 's', 't', cutoff=k)
+    ok_(k <= R.graph['flow_value'] <= 2 * k)

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -14,11 +14,9 @@ from networkx.algorithms.flow.shortest_augmenting_path import *
 
 ford_fulkerson = partial(ford_fulkerson, legacy=False)
 ford_fulkerson.__name__ = 'ford_fulkerson'
-preflow_push = partial(preflow_push, value_only=False)
-preflow_push.__name__ = 'preflow_push'
 
 flow_funcs = [edmonds_karp, ford_fulkerson, preflow_push,
-                shortest_augmenting_path]
+              shortest_augmenting_path]
 max_min_funcs = [nx.maximum_flow, nx.minimum_cut]
 all_funcs = sum([flow_funcs, max_min_funcs], [])
 
@@ -92,10 +90,11 @@ def compare_flows_and_cuts(G, s, t, solnFlows, solnValue, capacity='capacity'):
         # Minimum cut
         if legacy:
             partition = nx.minimum_cut(G, s, t,  capacity=capacity,
-                                    flow_func=nx.ford_fulkerson, value_only=False)
+                                       flow_func=nx.ford_fulkerson,
+                                       value_only=False)
         else:
             partition = nx.minimum_cut(G, s, t, capacity=capacity,
-                                    flow_func=flow_func, value_only=False)
+                                       flow_func=flow_func, value_only=False)
         validate_cuts(G, s, t, solnValue, partition, capacity, flow_func)
 
 
@@ -359,9 +358,9 @@ class TestMaxFlowMinCutInterface:
         G.add_weighted_edges_from([(0,1,1),(1,2,1),(2,3,1)],weight='capacity')
         for element in elements:
             assert_raises(nx.NetworkXError,
-                            nx.maximum_flow, G, 0, 1, flow_func=element)
+                          nx.maximum_flow, G, 0, 1, flow_func=element)
             assert_raises(nx.NetworkXError,
-                            nx.minimum_cut, G, 0, 1, flow_func=element)
+                          nx.minimum_cut, G, 0, 1, flow_func=element)
 
     def test_flow_func_parameter(self):
         G = nx.DiGraph()
@@ -388,13 +387,13 @@ class TestMaxFlowMinCutInterface:
         G.add_edge(1, 2, capacity = 1.0)
         fv = 1.0
         assert_equal(fv, nx.maximum_flow(G, 0, 2,
-                            flow_func=nx.shortest_augmenting_path, two_phase=True))
+                     flow_func=nx.shortest_augmenting_path, two_phase=True))
         assert_equal(fv, nx.minimum_cut(G, 0, 2,
-                            flow_func=nx.shortest_augmenting_path, two_phase=True))
+                     flow_func=nx.shortest_augmenting_path, two_phase=True))
         assert_equal(fv, nx.maximum_flow(G, 0, 2,
-                            flow_func=nx.preflow_push, global_relabel_freq=5))
+                     flow_func=nx.preflow_push, global_relabel_freq=5))
         assert_equal(fv, nx.minimum_cut(G, 0, 2,
-                            flow_func=nx.preflow_push, global_relabel_freq=5))
+                     flow_func=nx.preflow_push, global_relabel_freq=5))
 
 
 # Tests specific to one algorithm

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -380,6 +380,8 @@ class TestMaxFlowMinCutInterface:
                          msg=msg.format(flow_func.__name__))
             assert_equal(fv, nx.minimum_cut(G, 'x', 'y', flow_func=flow_func),
                          msg=msg.format(flow_func.__name__))
+            assert_raises(nx.NetworkXError, nx.minimum_cut, G, 'x', 'y',
+                          flow_func=flow_func, cutoff=1.0)
 
     def test_kwargs(self):
         G = nx.DiGraph()


### PR DESCRIPTION
I only added cutoff to `edmonds_karp` and `shortest_augmenting_path`. I suppose that I also know how to add this to `preflow_push`, but I cannot make sense of the residual network produced when both `value_only` is `True`, and `cutoff` is smaller than the maximum flow value. (To summarize, it represents a preflow that is not maximum; there is not _s_–_t_ paths, but the induced _s_–_t_ cut is not minimum. But then what?)

I also fixed `value_only` use in `minimum_cut`. It should be `True` when passed to the underlying maximum flow algorithm.
