### PR TITLE
Document minimum cut criterion in individual maxflow functions

### DIFF
--- a/networkx/algorithms/flow/edmonds_karp.py
+++ b/networkx/algorithms/flow/edmonds_karp.py
@@ -191,7 +191,10 @@ def edmonds_karp(G, s, t, capacity='capacity', value_only=False, cutoff=None):
     satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
 
     The flow value, defined as the total flow into :samp:`t`, the sink, is
-    stored in :samp:`R.graph['flow_value']`.
+    stored in :samp:`R.graph['flow_value']`. If :samp:`cutoff` is not
+    specified, reachability to :samp:`t` using only edges :samp:`(u, v)` such
+    that :samp:`R[u][v]['flow'] < R[u][v]['capacity']` induces a minimum
+    :samp:`s`-:samp:`t` cut.
 
     Examples
     --------

--- a/networkx/algorithms/flow/preflow_push.py
+++ b/networkx/algorithms/flow/preflow_push.py
@@ -355,7 +355,10 @@ def preflow_push(G, s, t, capacity='capacity', global_relabel_freq=1,
     satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
 
     The flow value, defined as the total flow into :samp:`t`, the sink, is
-    stored in :samp:`R.graph['flow_value']`.
+    stored in :samp:`R.graph['flow_value']`. Reachability to :samp:`t` using
+    only edges :samp:`(u, v)` such that
+    :samp:`R[u][v]['flow'] < R[u][v]['capacity']` induces a minimum
+    :samp:`s`-:samp:`t` cut.
 
     Examples
     --------

--- a/networkx/algorithms/flow/shortest_augmenting_path.py
+++ b/networkx/algorithms/flow/shortest_augmenting_path.py
@@ -241,7 +241,10 @@ def shortest_augmenting_path(G, s, t, capacity='capacity', value_only=False,
     satisfies :samp:`R[u][v]['flow'] == -R[v][u]['flow']`.
 
     The flow value, defined as the total flow into :samp:`t`, the sink, is
-    stored in :samp:`R.graph['flow_value']`.
+    stored in :samp:`R.graph['flow_value']`. If :samp:`cutoff` is not
+    specified, reachability to :samp:`t` using only edges :samp:`(u, v)` such
+    that :samp:`R[u][v]['flow'] < R[u][v]['capacity']` induces a minimum
+    :samp:`s`-:samp:`t` cut.
 
     Examples
     --------


### PR DESCRIPTION
I basically copy-pasted the notes from `maximum_flow` into the algorithms. It turns out that `preflow_push` needs some slightest modification because it does not support `cutoff`.
